### PR TITLE
Use PRIDE description to screen user prompts

### DIFF
--- a/load_model.py
+++ b/load_model.py
@@ -1,12 +1,14 @@
 import os
 import platform
-
+import re
 import torch
 import torch.cuda as cuda
 import transformers
 import yaml
 from transformers import AutoTokenizer, AutoModel, AutoModelForCausalLM, \
     BitsAndBytesConfig  # tool for loading model from huggingface
+from langchain.prompts import PromptTemplate
+
 
 # Variables initialization
 os_name = platform.system()
@@ -73,18 +75,71 @@ def llm_model_init(choice: str, gpu: bool):
 
 # chat with model
 def llm_chat(choice: str, prompt: str, tokenizer, model, query: str):
+    if screen_prompt(choice, query, tokenizer, model):
+        if choice == 'chatglm3-6b':  # chat with ChatGLM
+            result = model.chat(tokenizer, prompt, history=[])
+            result = result[0]
+        elif choice == 'llama2-13b-chat' or choice == 'Mixtral' or choice == 'open-hermes':
+            # inputs = tokenizer(prompt,return_tensors="pt").to("cuda:0")
+            out = model(
+                prompt,
+                truncation=True
+            )
+            # start_index = out[0]['generated_text'].find("###Questio:"+prompt)
+            # content_start = start_index + len("###Question:"+prompt) + 1
+            # end_index = out[0]['generated_text'].find("###", content_start)
+            # result = out[0]['generated_text'][content_start:end_index].strip()
+            result = out[0]['generated_text'].replace(prompt, "", 1).strip()
+    else:
+        result = ("You've asked a question that is not relevant to the PRIDE database, "
+                  "so I'm afraid I can't answer it. If you think this is a mistake, "
+                  "please get in touch!")
+    return result
+
+def screen_prompt(choice: str, query: str, tokenizer, model):
+    pride_description = """The PRIDE PRoteomics IDEntifications (PRIDE) Archive database is a centralized, standards compliant, 
+    public data repository for mass spectrometry proteomics data, including protein and peptide identifications and the corresponding 
+    expression values, post-translational modifications and supporting mass spectra evidence (both as raw data and peak list files). 
+    PRIDE is a core member in the ProteomeXchange (PX) consortium, which provides a standardised way for submitting mass spectrometry 
+    based proteomics data to public-domain repositories. Datasets are submitted to ProteomeXchange via PRIDE and are handled by 
+    expert bio-curators. All PRIDE public datasets can also be searched in ProteomeCentral, the portal for all ProteomeXchange 
+    datasets."""
+    if choice == 'chatglm3-6b':
+        prompt_template = """<s>[INST]
+                <<SYS>>
+                You are triaging requests sent to the PRIDE helpdesk. Your task is to briefly analyse and classify user queries
+                based on whether they are likely to be relevant to the PRIDE database, based on the following description of the 
+                PRIDE database:
+                {pride_description}
+                <</SYS>>
+                A user has asked the following question:
+                {query}
+                Given the description of the PRIDE database, is this question relevant to the PRIDE database? Answer only Yes or No.
+                [/INST]</s>""" 
+    elif choice == 'llama2-13b-chat' or choice == 'Mixtral' or choice == 'open-hermes':
+        prompt_template = """[INST]
+                You are triaging requests sent to the PRIDE helpdesk. Your task is to briefly analyse and classify user queries
+                based on whether they are likely to be relevant to the PRIDE database, based on the following description of the 
+                PRIDE database:
+                {pride_description}
+                A user has asked the following question:
+                {query}
+                Given the description of the PRIDE database, is this question relevant to the PRIDE database? Answer only Yes or No.
+                [/INST]""" 
+    prompt = PromptTemplate(
+        template=prompt_template,
+        input_variables=["context", "question"]
+    )
+    prompt = prompt.format(pride_description, query)
     if choice == 'chatglm3-6b':  # chat with ChatGLM
         result = model.chat(tokenizer, prompt, history=[])
         result = result[0]
     elif choice == 'llama2-13b-chat' or choice == 'Mixtral' or choice == 'open-hermes':
-        # inputs = tokenizer(prompt,return_tensors="pt").to("cuda:0")
         out = model(
             prompt,
             truncation=True
         )
-        # start_index = out[0]['generated_text'].find("###Questio:"+prompt)
-        # content_start = start_index + len("###Question:"+prompt) + 1
-        # end_index = out[0]['generated_text'].find("###", content_start)
-        # result = out[0]['generated_text'][content_start:end_index].strip()
         result = out[0]['generated_text'].replace(prompt, "", 1).strip()
-    return result
+
+    ## Look at the output and see what the LLM thinks
+    return re.search('[Yy]es', result)


### PR DESCRIPTION
This adds an extra round of inference to get the model to explicitly classify a user's prompt as being related to PRIDE or not.

We use the pride description from here https://www.ebi.ac.uk/pride/markdownpage/citationpage (which is probably in the markdown in the repo somewhere) and ask if the prompt is directly relevant.

I haven't tested with the full server yet, but I think it should work ok